### PR TITLE
Update default src and output dirs and remove unused gulp-notify module

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ Elixir.extend("compass", function(src, output, options) {
             style:       config.css.sass.pluginOptions.outputStyle,
             image:       config.publicPath + '/images',
             font:        config.publicPath + '/fonts',
-            sass:        config.css.sass.folder,
-            css:         output || config.css.outputFolder
+            sass:        config.assetsPath + '/' + config.css.sass.folder,
+            css:         output || config.publicPath + '/' + config.css.outputFolder
         };
 
     options = _.extend(defaultOptions, options);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/joecianflone/laravel-elixir-sass-compass",
   "dependencies": {
     "gulp-compass": "^2.1.0",
-    "gulp-notify": "^2.2.0",
     "underscore": "^1.8.2"
   }
 }


### PR DESCRIPTION
Ok, here's a scenario.

By default, Laravel will look through `resources/assets/sass` directory to find all `sass` files and it will compile and output into `public/css` directory.

 But, if you have in your `gulpfile.js` the following code: 

``` js
mix.compass('app.scss');
```

and run the `gulp compass` command, it will compile `sass/app.scss` into `css/app.css` file, which is not correct. 

Just like the `gulp sass` command is looking for `resources/assets/sass/app.scss` file to compile it into `public/css/app.css` file, this compass extension should do the same, which is fixed in this commit.

And for those, who, are using Elixir with Non-Laravel project, they can change the source and destination path's with the following lines of code in their `elixir.json` file:

``` json
{
  "assetsPath" : "src",
  "publicPath" : "dist"
}
```

In this case, all sass files from `src/sass` directory will be compiled into `dist/css` directory.

Alternatively, they can change the source and destination path's in the `options` of compass extension like this:

``` js
mix.compass('app.scss', 'path/to/output', {
    sass: 'path/to/src/'
});
```

In this way, the `gulpfile.js` and optional `elixir.json` will be much more cleaner and simpler. 
